### PR TITLE
Add periphery mode

### DIFF
--- a/app.py
+++ b/app.py
@@ -187,10 +187,6 @@ class App(tk.Tk):
         else:
             self.release_delay_button.grid_remove()
             self.release_delay_label.grid_remove()
-        if self.settings.periphery_mode_enabled:
-            self.canvas_frame.set_background_colour(self.settings.periphery_background_colour)
-        else:
-            self.canvas_frame.set_background_colour(self.canvas_frame.default_background_colour)
         self.canvas_frame.refresh()
 
         

--- a/app.py
+++ b/app.py
@@ -139,6 +139,15 @@ class App(tk.Tk):
                                              background='white')
         self.release_delay_label.grid(row=0, column=1, padx=10, pady=5)
 
+        # periphery mode
+        ttk.Label(self.tab1, text='periphery mode', font='tkDefaulFont 14 bold').pack()
+        self.periphery_mode_enabled = tk.BooleanVar(self, self.settings.periphery_mode_enabled)
+        self.periphery_mode_enabled_check = tk.Checkbutton(self.tab1, text='enable periphery mode',
+                                                           command=self.update_display_settings,
+                                                           variable=self.periphery_mode_enabled)
+        self.periphery_mode_enabled_check.pack()
+        ttk.Label(self.tab1, text='see settings.yaml to modify periphery mode', font='tkDefaulFont 8').pack()
+
         # display
         self.canvas_frame = Canvas_Frame(self.settings, self.tab2, width=400, height=600)
         self.canvas_frame.grid(row=2, column=0, sticky='nw')
@@ -155,10 +164,11 @@ class App(tk.Tk):
         self.settings.key_display_method = self.key_display_var.get()
         self.settings.do_colour = self.do_colour_var.get()
         self.settings.do_full_release = self.do_full_release_var.get()
-        self.canvas_frame.refresh()
+        self.settings.periphery_mode_enabled = self.periphery_mode_enabled.get()
         logging.info(f'current display method: {self.settings.key_display_method}')
         logging.info(f'current colour mode: {self.settings.do_colour}')
         logging.info(f'current full release mode: {self.settings.do_full_release}')
+        logging.info(f'periphery mode enabled: {self.settings.periphery_mode_enabled}')
         if self.settings.do_colour:
             for colour_button in self.colour_buttons:
                 colour_button.grid()
@@ -177,6 +187,11 @@ class App(tk.Tk):
         else:
             self.release_delay_button.grid_remove()
             self.release_delay_label.grid_remove()
+        if self.settings.periphery_mode_enabled:
+            self.canvas_frame.set_background_colour(self.settings.periphery_background_colour)
+        else:
+            self.canvas_frame.set_background_colour(self.canvas_frame.default_background_colour)
+        self.canvas_frame.refresh()
 
         
         

--- a/canvas_frame.py
+++ b/canvas_frame.py
@@ -64,8 +64,8 @@ class Canvas_Frame(ttk.Frame):
         decay = self.settings.periphery_decay_ms
         fps = 30
 
-        steps = int(decay / fps)
-        delay = int(decay / steps)
+        delay = int(1000 / fps)
+        steps = int(decay / delay)
 
         for step in range(steps + 1):
             fraction = step / steps

--- a/canvas_frame.py
+++ b/canvas_frame.py
@@ -44,11 +44,13 @@ class Canvas_Frame(ttk.Frame):
         self.canvas.config(scrollregion=self.canvas.bbox('all'))
         self.canvas.yview_moveto(1)
 
+
     def draw_colour_mistake(self, mistake):
         for rule in self.settings.periphery_rules:
             if re.search(rule['regex'], mistake.get_mistake_text()):
                 self.flash_background(rule['colour'])
-        
+
+
     def flash_background(self, hex_colour):
         self.current_flash_id = datetime.datetime.now().timestamp()
         flash_id = self.current_flash_id
@@ -115,7 +117,10 @@ class Canvas_Frame(ttk.Frame):
         self.configure(width=self.get_max_linewidth() + self.settings.font_size)
         self.canvas.delete('all')
         self.canvas_lines = []
-        if not self.settings.periphery_mode_enabled:
+        if self.settings.periphery_mode_enabled:
+            self.set_background_colour(self.settings.periphery_background_colour)
+        else:
+            self.set_background_colour(self.default_background_colour)
             for mistake in self.mistakes:
                 self.draw_text_mistake(mistake)
             

--- a/main.py
+++ b/main.py
@@ -17,14 +17,7 @@ def main():
     abspath = os.path.abspath(__file__)
     dirname = os.path.dirname(abspath)
     os.chdir(dirname)
-    try:
-        logging.info('loading settings from file')
-        with open(SETTINGS_PATH, 'rb') as file:
-            settings = pickle.load(file)
-    except FileNotFoundError:
-        logging.warning('could not load settings from file, falling back to defaults')
-        settings = Setting_Handler()
-        
+    settings = Setting_Handler(SETTINGS_PATH)
     app = App(settings)
     app.mainloop()
 

--- a/mistake.py
+++ b/mistake.py
@@ -16,8 +16,8 @@ class Mistake():
         else:
             self.time = time
             
-    def get_display_values (self):
-        match self.settings.key_display_method:
+    def get_display_values (self, key_display_method):
+        match key_display_method:
             case 'key numbers':
                 return [str(i + 1) for i in self.keyindices]
             case 'key binds':
@@ -30,6 +30,9 @@ class Mistake():
             return [self.settings.colours[i] for i in self.keyindices]
         else:
             return ['black' for i in self.keyindices]
+
+    def get_mistake_text(self):
+        raise NotImplementedError()
     
     
 class Keylock(Mistake):
@@ -38,7 +41,7 @@ class Keylock(Mistake):
         super().__init__(settings, keyindices, time)
     
     def create_canvas_line(self, canvas, x, y):
-        display_values = self.get_display_values()
+        display_values = self.get_display_values(self.settings.key_display_method)
         colours = self.get_colours()
         line = Canvas_Textline(self.settings, canvas, x, y)
         line.add_text(self.time.strftime('[%H:%M:%S] '), fill='gray')
@@ -47,6 +50,10 @@ class Keylock(Mistake):
         line.add_text('-')
         line.add_text(display_values[1], fill=colours[1])
         return line
+
+    def get_mistake_text(self):
+        key_numbers = self.get_display_values('key numbers')
+        return f"keylocked {key_numbers[0]}-{key_numbers[1]}"
     
     
 class Repeat(Mistake):
@@ -58,13 +65,17 @@ class Repeat(Mistake):
             super().__init__(settings, [keyindices], time)
     
     def create_canvas_line(self, canvas, x, y):
-        display_values = self.get_display_values()
+        display_values = self.get_display_values(self.settings.key_display_method)
         colours = self.get_colours()
         line = Canvas_Textline(self.settings, canvas, x, y)
         line.add_text(self.time.strftime('[%H:%M:%S] '), fill='gray')
         line.add_text('repeated ')
         line.add_text(display_values[0], fill=colours[0])
         return line
+
+    def get_mistake_text(self):
+        key_numbers = self.get_display_values('key numbers')
+        return f"repeated {key_numbers[0]}"
     
     
 class Skip(Mistake):
@@ -76,7 +87,7 @@ class Skip(Mistake):
             super().__init__(settings, [keyindices], time)
     
     def create_canvas_line(self, canvas, x, y):
-        display_values = self.get_display_values()
+        display_values = self.get_display_values(self.settings.key_display_method)
         colours = self.get_colours()
         line = Canvas_Textline(self.settings, canvas, x, y)
         line.add_text(self.time.strftime('[%H:%M:%S] '), fill='gray')
@@ -86,3 +97,7 @@ class Skip(Mistake):
             line.add_text(', ')
         line.add_text(display_values[-1], fill=colours[-1])
         return line
+
+    def get_mistake_text(self):
+        key_numbers = self.get_display_values('key numbers')
+        return "skipped " + ", ".join(key_numbers)

--- a/setting_handler.py
+++ b/setting_handler.py
@@ -1,34 +1,74 @@
-
-import keyboard as kb
+import yaml
 import logging
-import pickle
 
-SETTINGS_PATH = 'settings.p'
+SETTINGS_PATH = 'settings.yaml'
 
-class Setting_Handler():
-    def __init__(self):
-        # keys
-        self.KEYS = 4
-        self.bind_names = ['a', 's', 'd', 'space', '`']
-        self.bind_codes = [30, 31, 32, 57, 41]
-        self.colours = ['#DC0014', '#FF8C0A', '#00C1C1', '#2832E6']
-        self.aliases = ['ring', 'middle', 'index', 'thumb']
-        
-        # display options
-        self.key_display_method = 'key numbers'
-        self.font_size = 18
-        self.relative_pad_left = 0.5
-        self.line_spacing = 1.5
-        self.do_colour = True
+class Setting_Handler:
+    def __init__(self, settings_path=SETTINGS_PATH):
+        self.settings_path = settings_path
+        self._load_settings()
 
-        # behavior
-        self.do_full_release = True
-        self.release_seconds = 2
-        
-    def save(self, settings_path='settings.p'):
-        logging.info('saving settings to file')
-        with open(settings_path, 'wb') as file:
-            pickle.dump(self, file)
-            
-    def reset(self):
-        self = Setting_Handler()
+    def _load_settings(self):
+        try:
+            logging.info(f"Attempting to load settings from '{self.settings_path}'")
+            with open(self.settings_path, 'r') as file:
+                settings_data = yaml.safe_load(file)
+                if not settings_data:
+                    raise FileNotFoundError
+            logging.info("Settings loaded successfully.")
+        except FileNotFoundError:
+            logging.warning(f"'{self.settings_path}' not found or is empty.")
+
+        self.KEYS = settings_data['keys']['count']
+        self.bind_names = settings_data['keys']['bind_names']
+        self.bind_codes = settings_data['keys']['bind_codes']
+        self.colours = settings_data['keys']['colours']
+        self.aliases = settings_data['keys']['aliases']
+
+        self.key_display_method = settings_data['display']['key_display_method']
+        self.font_size = settings_data['display']['font_size']
+        self.relative_pad_left = settings_data['display']['relative_pad_left']
+        self.line_spacing = settings_data['display']['line_spacing']
+        self.do_colour = settings_data['display']['do_colour']
+
+        self.do_full_release = settings_data['behavior']['do_full_release']
+        self.release_seconds = settings_data['behavior']['release_seconds']
+        self.periphery_mode_enabled = settings_data['periphery_mode']['enabled']
+        self.periphery_decay_ms = settings_data['periphery_mode']['decay_ms']
+        self.periphery_background_colour = settings_data['periphery_mode']['background_colour']
+        self.periphery_rules = settings_data['periphery_mode']['rules']
+
+    def save(self):
+        settings_data = {
+            'keys': {
+                'count': self.KEYS,
+                'bind_names': self.bind_names,
+                'bind_codes': self.bind_codes,
+                'colours': self.colours,
+                'aliases': self.aliases,
+            },
+            'display': {
+                'key_display_method': self.key_display_method,
+                'font_size': self.font_size,
+                'relative_pad_left': self.relative_pad_left,
+                'line_spacing': self.line_spacing,
+                'do_colour': self.do_colour,
+            },
+            'behavior': {
+                'do_full_release': self.do_full_release,
+                'release_seconds': self.release_seconds,
+            },
+            'periphery_mode': {
+                'enabled': self.periphery_mode_enabled,
+                'decay_ms': self.periphery_decay_ms,
+                'background_colour': self.periphery_background_colour,
+                'rules': self.periphery_rules,
+            }
+        }
+
+        try:
+            with open(self.settings_path, 'w') as file:
+                yaml.safe_dump(settings_data, file)
+            logging.info(f"Settings saved successfully to '{self.settings_path}'")
+        except Exception as e:
+            logging.error(f"Failed to save settings: {e}")

--- a/settings.yaml
+++ b/settings.yaml
@@ -1,0 +1,44 @@
+behavior:
+  do_full_release: true
+  release_seconds: 2
+display:
+  do_colour: true
+  font_size: 18
+  key_display_method: key numbers
+  line_spacing: 1.5
+  relative_pad_left: 0.5
+keys:
+  aliases:
+  - ring
+  - middle
+  - index
+  - thumb
+  bind_codes:
+  - 30
+  - 31
+  - 32
+  - 57
+  - 41
+  bind_names:
+  - a
+  - s
+  - d
+  - space
+  - '`'
+  colours:
+  - '#DC0014'
+  - '#FF8C0A'
+  - '#00C1C1'
+  - '#2832E6'
+  count: 4
+periphery_mode:
+  background_colour: '#000000'
+  decay_ms: 400
+  enabled: false
+  rules:
+  - colour: '#FF3333'
+    regex: keylocked 1-3|keylocked 3-1
+  - colour: '#334AFF'
+    regex: keylocked 2-4|keylocked 4-2
+  - colour: '#FF33F9'
+    regex: skipped*|repeat*


### PR DESCRIPTION
Add a new mode "periphery mode". When enabled, the display swaps to show a solid color, flashing some specified color when some rule is satisfied. These rules are defined in settings.yaml -> periphery_mode->rules

Additionally swap settings to be saved and read through a YAML file instead of a pickled object. This allows having settings that are not surfaced through the settings GUI. This is necessary since it would be overly complicated to manage the settings for an arbitrary number of rules through GUI instead of a config file.